### PR TITLE
coquille : w4s1c3-isinstance

### DIFF
--- a/w4/w4-s1-c3-isinstance.ipynb
+++ b/w4/w4-s1-c3-isinstance.ipynb
@@ -218,7 +218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Vous voyez qu'ici, bien que l'objet baleine est de type `Mammifere`, on peut le considérer comme étant **aussi** de type `Animal`. \n",
+    "Vous voyez qu'ici, bien que l'objet baleine soit de type `Mammifere`, on peut le considérer comme étant **aussi** de type `Animal`. \n",
     "\n",
     "Ceci est motivé de la façon suivante : comme on l'a dit plus haut, tout ce qu'on peut faire (en termes notamment d'envoi de méthodes) sur un objet de type `Animal`, on peut le faire sur un objet de type `Mammifere`. Dit en termes ensemblistes, l'ensemble des mammifères est inclus dans l'ensemble des animaux."
    ]


### PR DESCRIPTION
>  bien que l'objet baleine **<strike>est</strike>**  ***soit***  de type Mammifere

La conjonction de subordination «bien que» peut être suivie du subjonctif ou du participe, mais en aucun cas de l'indicatif.