### PR TITLE
w3-s1-c2-utilitaires-sur-fichiers.ipynb : traductions manquantes

### DIFF
--- a/w3/w3-s1-c2-utilitaires-sur-fichiers.ipynb
+++ b/w3/w3-s1-c2-utilitaires-sur-fichiers.ipynb
@@ -65,8 +65,8 @@
    "source": [
     "* `os.path.join` ajoute '/' ou '\\' entre deux morceaux de chemin, selon l'OS\n",
     "* `os.path.basename` trouve le nom de fichier dans un chemin\n",
-    "* `os.path.dirname` trouve le nom du directory dans un chemin\n",
-    "* `os.path.abspath` calcule un chemin absolu, c'est-à-dire à partir de la racine du filesystem "
+    "* `os.path.dirname` trouve le nom du répertoire dans un chemin\n",
+    "* `os.path.abspath` calcule un chemin absolu, c'est-à-dire à partir de la racine du système de fichier"
    ]
   },
   {


### PR DESCRIPTION
Un petit oubli dans les traductions des définitions :

- <strike>directory</strike> -> **répertoire** 
- <strike>filesystem</strike> '> **système de fichier**

Github à rajouté un NEWLINE à la fin du fichier à la validation du commit...
... Je l'ai laissé (-: