### PR TITLE
Relecture w3

### DIFF
--- a/w3/w3-s1-c1-fichiers.ipynb
+++ b/w3/w3-s1-c1-fichiers.ipynb
@@ -215,7 +215,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Comme nous allons utiliser maintenant des outils d'assez bas niveau pour lire du texte, aussi pour examiner ce texte nous allons utiliser la fonction `repr()`, et voici pourquoi :"
+    "Comme nous allons utiliser maintenant des outils d'assez bas niveau pour lire du texte, pour examiner ce texte nous allons utiliser la fonction `repr()`, et voici pourquoi :"
    ]
   },
   {
@@ -272,7 +272,7 @@
    "outputs": [],
    "source": [
     "# read() retourne TOUT le contenu\n",
-    "# ne pas utiliser avec de très gros fichier bien sûr\n",
+    "# ne pas utiliser avec de très gros fichiers bien sûr\n",
     "\n",
     "# une autre façon de montrer tout le contenu du fichier\n",
     "with open(\"foo.txt\", encoding='utf-8') as entree:\n",
@@ -338,7 +338,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Les fichiers que nous avons vus jusqu'ici étaient ouverts en mode *textuel* (c'est le défaut), et c'est pourquoi quand nous avons interagi avec eux avec des objets de type `str` :"
+    "Les fichiers que nous avons vus jusqu'ici étaient ouverts en mode *textuel* (c'est le défaut), et c'est pourquoi nous avons interagi avec eux avec des objets de type `str` :"
    ]
   },
   {
@@ -378,7 +378,7 @@
    "outputs": [],
    "source": [
     "# phase 1 : on écrit un fichier avec du texte en UTF-8\n",
-    "# on ouvre le donc le fichier en mode texte\n",
+    "# on ouvre donc le fichier en mode texte\n",
     "# en toute rigueur il faut préciser l'encodage,\n",
     "# si on ne le fait pas il sera déterminé\n",
     "# à partir de vos réglages système\n",
@@ -407,7 +407,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Vous retrouvez ainsi le fait que l'unique caractère Unicode `é`, a été encodé par UTF-8 sous la forme de deux octets de code hexadécimal `0xc3` et `0xa9`."
+    "Vous retrouvez ainsi le fait que l'unique caractère Unicode `é` a été encodé par UTF-8 sous la forme de deux octets de code hexadécimal `0xc3` et `0xa9`."
    ]
   },
   {
@@ -452,7 +452,7 @@
    "source": [
     "Pour une description exhaustive vous pouvez vous reporter :\n",
     "* au [glossaire sur la notion de `object file`](https://docs.python.org/3/glossary.html#term-file-object),\n",
-    "* et aussi et surtout [au module `io`](https://docs.python.org/3/library/io.html#module-io) qui décrit plus en détails les fonctionnalités disponibles."
+    "* et aussi et surtout [au module `io`](https://docs.python.org/3/library/io.html#module-io) qui décrit plus en détail les fonctionnalités disponibles."
    ]
   }
  ],

--- a/w3/w3-s1-c2-utilitaires-sur-fichiers.ipynb
+++ b/w3/w3-s1-c2-utilitaires-sur-fichiers.ipynb
@@ -116,7 +116,7 @@
    "source": [
     "Comme on l'a mentionné précédemment `pathlib` offre une interface orientée objet ; mais qu'est-ce que ça veut dire au juste ?\n",
     "\n",
-    "Ceci nous donne un prétexte pour une première application pratique des notions de module (que nous avons introduits en fin de semaine 2) et de classe (que nous allons voir en fin de semaine)."
+    "Ceci nous donne un prétexte pour une première application pratique des notions de module (que nous avons introduite en fin de semaine 2) et de classe (que nous allons voir en fin de semaine)."
    ]
   },
   {
@@ -335,7 +335,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ou encore, si je formatte pour n'obtenir que\n",
+    "# ou encore, si je formate pour n'obtenir que\n",
     "# l'heure et la minute\n",
     "f\"{mtime_datetime:%H:%M}\""
    ]

--- a/w3/w3-s1-c3-format-json-et-autres.ipynb
+++ b/w3/w3-s1-c3-format-json-et-autres.ipynb
@@ -208,7 +208,7 @@
     "\n",
     "Cela dit, la puissance, et donc le coût, de XML et JSON ne sont pas du tout comparables, XML étant beaucoup plus flexible mais au prix d'une complexité de mise en œuvre très supérieure.\n",
     "\n",
-    "Il existe plusieurs souches différentes de librairies prenant en charge le format XML, [qui sont introduites ici](https://docs.python.org/3/library/xml.html)."
+    "Il existe plusieurs souches différentes de bibliothèques prenant en charge le format XML, [qui sont introduites ici](https://docs.python.org/3/library/xml.html)."
    ]
   },
   {

--- a/w3/w3-s2-c1-tuple-et-virgule.ipynb
+++ b/w3/w3-s2-c1-tuple-et-virgule.ipynb
@@ -51,7 +51,7 @@
     "couple2 = (1, 2)\n",
     "# avec virgule terminale\n",
     "couple3 = 1, 2,\n",
-    "# avec parenthèse et virgule\n",
+    "# avec parenthèses et virgule\n",
     "couple4 = (1, 2,)"
    ]
   },

--- a/w3/w3-s2-c2-sequence-unpacking.ipynb
+++ b/w3/w3-s2-c2-sequence-unpacking.ipynb
@@ -189,7 +189,7 @@
     "\n",
     "* le terme à droite du signe `=` soit un *itérable* (tuple, liste, string, etc.) ;\n",
     "* le terme à gauche soit écrit comme un tuple ou une liste - notons tout de même que l'utilisation d'une liste à gauche est rare et peu pythonique ;\n",
-    "* les deux termes aient la même longueur - en tous cas avec les concepts que l'on a vus jusqu'ici, mais voir aussi plus bas l'utilisation de `*arg` avec le *extended unpacking*."
+    "* les deux termes aient la même longueur - en tout cas avec les concepts que l'on a vus jusqu'ici, mais voir aussi plus bas l'utilisation de `*arg` avec le *extended unpacking*."
    ]
   },
   {

--- a/w3/w3-s2-q1-tuples.quiz
+++ b/w3/w3-s2-q1-tuples.quiz
@@ -53,9 +53,9 @@ Quelles sont parmi les affectations suivantes celles qui sont valables, et qui a
 
 
 [explanation]
-Dans la première forme, <code>four</code> ne se trouve pas dans un tuple à cause de l'absence de virgule; du coup <code>four</code> va valoir <code> &#91;(4,)&#93;</code> et non pas <code>4</code>.
+Dans la première forme, <code>four</code> ne se trouve pas dans un tuple à cause de l'absence de virgule ; du coup <code>four</code> va valoir <code> &#91;(4,)&#93;</code> et non pas <code>4</code>.
 La seconde forme est correcte.
-Dans la troisième forme, <code>one</code> est inclus dans un tuple, ce qui empêche l'affectation de fonctionner
+Dans la troisième forme, <code>one</code> est inclus dans un tuple, ce qui empêche l'affectation de fonctionner.
 La dernière forme est correcte, même si les parties droite et gauche de l'affectation mélangent listes et tuples.
 [explanation]
 

--- a/w3/w3-s2-x1-comptage.ipynb
+++ b/w3/w3-s2-x1-comptage.ipynb
@@ -132,7 +132,7 @@
     "\n",
     "Pour les courageux, je vous donne également [\"Une charogne\" en ISO-8859-15](data/une_charogne_iso15.txt), qui contient le même texte que \"Une charogne\", mais encodé en Latin-9, connu aussi sous le nom ISO-8859-15.\n",
     "\n",
-    "Ce dernier fichier n'est pas à prendre en compte dans la version basique de l'exercice, mais vous pourrez vous rendre compte par vous même, au cas où cela ne serait pas clair encore pour vous, qu'il n'est pas facile d'écrire une fonction `comptage` qui devine l'encodage, c'est-à-dire qui fonctionne correctement avec des entrées indifféremment en Unicode ou Latin, sans que cet encodage soit passé en paramètre à `comptage`."
+    "Ce dernier fichier n'est pas à prendre en compte dans la version basique de l'exercice, mais vous pourrez vous rendre compte par vous-mêmes, au cas où cela ne serait pas clair encore pour vous, qu'il n'est pas facile d'écrire une fonction `comptage` qui devine l'encodage, c'est-à-dire qui fonctionne correctement avec des entrées indifféremment en Unicode ou Latin, sans que cet encodage soit passé en paramètre à `comptage`."
    ]
   },
   {

--- a/w3/w3-s4-c1-dictionnaires.ipynb
+++ b/w3/w3-s4-c1-dictionnaires.ipynb
@@ -382,7 +382,7 @@
     "%%python2\n",
     "\n",
     "# cette cellule utilise python-2.7 pour illustrer le fait\n",
-    "# que les dictionnaires ne sont pas ordonnes\n",
+    "# que les dictionnaires ne sont pas ordonnés\n",
     "\n",
     "d = {'c' : 3, 'b' : 1, 'a' : 2}\n",
     "for k, v in d.items():\n",
@@ -500,7 +500,7 @@
    "source": [
     "from collections import defaultdict\n",
     "\n",
-    "# on indique que les valeurs doivent être créés à la volée\n",
+    "# on indique que les valeurs doivent être créées à la volée\n",
     "# en utilisant la fonction list\n",
     "resultat = defaultdict(list)\n",
     "\n",

--- a/w3/w3-s4-c2-cles-immuables.ipynb
+++ b/w3/w3-s4-c2-cles-immuables.ipynb
@@ -96,7 +96,7 @@
    "source": [
     "Le point important ici, est qu'il **ne suffit pas**, pour une clé, d'être **de type immuable**.\n",
     "\n",
-    "On peut le voir sur un exemple très simple ; donnons nous donc un dictionnaire :"
+    "On peut le voir sur un exemple très simple ; donnons-nous donc un dictionnaire :"
    ]
   },
   {

--- a/w3/w3-s4-c3-record-et-dictionnaire.ipynb
+++ b/w3/w3-s4-c3-record-et-dictionnaire.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Il nous faut faire le lien entre dictionnaire Python et la notion d'enregistrement, c'est-à-dire une donnée composite qui contient plusieurs champs. (À cette notion correspond, selon les langages, ce qu'on appelle un `struct` ou un `record`)\n",
+    "Il nous faut faire le lien entre dictionnaire Python et la notion d'enregistrement, c'est-à-dire une donnée composite qui contient plusieurs champs. (À cette notion correspond, selon les langages, ce qu'on appelle un `struct` ou un `record`.)\n",
     "\n",
     "Imaginons qu'on veuille manipuler un ensemble de données concernant des personnes ; chaque personne est supposée avoir un nom, un âge et une adresse mail.\n",
     "\n",
@@ -128,7 +128,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Attardons nous un tout petit peu ; nous avons construit un dictionnaire par compréhension, en créant autant d'entrées que de personnes. Nous aborderons en détail la notion de compréhension de sets et de dictionnaires en semaine 5, donc si cette notation vous paraît étrange pour le moment, pas d'inquiétude.\n",
+    "Attardons-nous un tout petit peu ; nous avons construit un dictionnaire par compréhension, en créant autant d'entrées que de personnes. Nous aborderons en détail la notion de compréhension de sets et de dictionnaires en semaine 5, donc si cette notation vous paraît étrange pour le moment, pas d'inquiétude.\n",
     "\n",
     "Le résultat est donc un dictionnaire qu'on peut afficher comme ceci :"
    ]

--- a/w3/w3-s4-x2-marine-dict.ipynb
+++ b/w3/w3-s4-x2-marine-dict.ipynb
@@ -338,7 +338,7 @@
     "# le résultat attendu\n",
     "result_merge = exo_merge.resultat(extended, abbreviated)\n",
     "\n",
-    "# a quoi ressemble le résultat pour un bateau au hasard\n",
+    "# à quoi ressemble le résultat pour un bateau au hasard\n",
     "from pprint import pprint\n",
     "for key_value in result_merge.items():\n",
     "    pprint(key_value)\n",

--- a/w3/w3-s5-q1-ensembles.quiz
+++ b/w3/w3-s5-q1-ensembles.quiz
@@ -12,15 +12,15 @@ Parmi les objets suivants, lesquels peut-on insérer comme élément dans un ens
 [explanation]
 Pour pouvoir être inséré dans un objet <code>set</code>, un objet doit être globalement immuable.
 
-option 1: ce qui n'est évidemment pas le cas pour un <code>set</code>, dans lequel on peut insérer et enlever des éléments.
+option 1 : Ce qui n'est évidemment pas le cas pour un <code>set</code>, dans lequel on peut insérer et enlever des éléments.
 
-option 2: le type <code>frozenset</code> est immuable; de plus comme un <code>frozenset</code> est un ensemble, tous ses éléments sont aussi globalement immuables, donc l'objet lui-même est globalement immuable.
+option 2 : Le type <code>frozenset</code> est immuable ; de plus comme un <code>frozenset</code> est un ensemble, tous ses éléments sont aussi globalement immuables, donc l'objet lui-même est globalement immuable.
 
-option3: le tuple est immuable mais ses éléments ne le sont pas, on ne peut donc pas insérer ce tuple dans un ensemble.
+option 3 : Le tuple est immuable mais ses éléments ne le sont pas, on ne peut donc pas insérer ce tuple dans un ensemble.
 
-option 4: un tuple d'objets globalement immuables est immuable.
+option 4 : Un tuple d'objets globalement immuables est immuable.
 
-option 5: la liste elle-même est mutable.
+option 5 : La liste elle-même est mutable.
 [explanation]
 
 <hr/>
@@ -36,9 +36,9 @@ Pour créer un ensemble <code>set</code> vide en Python on peut faire :
 [explanation]
 La première forme renvoie un objet de type <code>dict</code>.
 
-Les deux autres formes fonctionnent très bien; la logique ici est qu'on appelle la fonction <code>set</code> qui est un constructeur d'ensemble, ou si on préfère, un convertisseur vers le type <code>set</code>.
+Les deux autres formes fonctionnent très bien ; la logique ici est qu'on appelle la fonction <code>set</code> qui est un constructeur d'ensemble, ou si on préfère, un convertisseur vers le type <code>set</code>.
 
-La fonction <code>set</code> accepte donc en argument un objet de type quelconque et s'efforce de le traduire dans un ensemble. Lorsqu'on ne passe aucun argument à <code>set</code> (option 2), ou qu'on lui passe une liste vide, <code>set</code> renvoie naturellement un ensemble vide; on aurait pu utiliser aussi bien, de la même manière, <code>set(())</code>, <code>set({})</code>, ou même <code>set('')</code> pour arriver au même résultat.
+La fonction <code>set</code> accepte donc en argument un objet de type quelconque et s'efforce de le traduire dans un ensemble. Lorsqu'on ne passe aucun argument à <code>set</code> (option 2), ou qu'on lui passe une liste vide, <code>set</code> renvoie naturellement un ensemble vide ; on aurait pu utiliser aussi bien, de la même manière, <code>set(())</code>, <code>set({})</code>, ou même <code>set('')</code> pour arriver au même résultat.
 [explanation]
 
 <hr/>

--- a/w3/w3-s5-x1-read-set.ipynb
+++ b/w3/w3-s5-x1-read-set.ipynb
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`read_set` va prendre en argument un nom de fichier (vous pouvez supposer qu'il existe), enlever les espaces éventuels au début et à la fin de chaque ligne, et construire un ensemble de toutes les lignes ; par exemple :"
+    "`read_set` va prendre en argument un nom de fichier (vous pouvez supposer qu'il existe), enlever les espaces éventuelles au début et à la fin de chaque ligne, et construire un ensemble de toutes les lignes ; par exemple :"
    ]
   },
   {

--- a/w3/w3-s6-c1-try-finally.ipynb
+++ b/w3/w3-s6-c1-try-finally.ipynb
@@ -107,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "La logique ici est assez similaire, sauf que le code du `else` n'est exécutée que dans le cas où aucune exception n'est attrapée."
+    "La logique ici est assez similaire, sauf que le code du `else` n'est exécuté que dans le cas où aucune exception n'est attrapée."
    ]
   },
   {

--- a/w3/w3-s6-q1-exceptions.quiz
+++ b/w3/w3-s6-q1-exceptions.quiz
@@ -33,7 +33,7 @@ On a du code qui peut produire une exception <code>TypeError</code>. Cochez les 
 
 
 [explanation]
-On doit capturer les exceptions qui sont prévisibles et donc on doit éviter de capturer <code>Exception</code> qui permet de capturer toutes les exceptions d'un coup et qui donc peut cacher une exception que nous n'avions par prévue et pour laquelle on n'a implémenté aucun comportement spécifique. 
+On doit capturer les exceptions qui sont prévisibles et donc on doit éviter de capturer <code>Exception</code> qui permet de capturer toutes les exceptions d'un coup et qui donc peut cacher une exception que nous n'avions pas prévue et pour laquelle on n'a implémenté aucun comportement spécifique. 
 
 Une exception peut se capturer n'importe où dans la pile d'exécution, mais on recommande en général de capturer l'exception au plus près de là où elle est produite. 
 [explanation]

--- a/w3/w3-s7-c3-les-differentes-copies.ipynb
+++ b/w3/w3-s7-c3-les-differentes-copies.ipynb
@@ -296,7 +296,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# voir la cellule ci-dessous si ceci vous parait peu clair\n",
     "for i, (source_item, deep_item) in enumerate(zip(source, deep_copy)):\n",
     "    compare = source_item is deep_item\n",
     "    print(f\"source[{i}] is deep_copy[{i}] -> {compare}\")"

--- a/w3/w3-s7-q1-shared-references.quiz
+++ b/w3/w3-s7-q1-shared-references.quiz
@@ -41,14 +41,14 @@ Qu'obtient-on comme valeur pour <code>liste</code> ? :
 (x) <code>&#91;&#91;1], [1], [1]]</code>
 
 [explanation]
-Cette fois on modifie en place la liste référencée par <code>cellule</code>, qui est partagée par les trois éléments de liste, on est dans le cas d'une référence partagée, la modification affecte les 3 éléments de la liste.
+Cette fois on modifie en place la liste référencée par <code>cellule</code>, qui est partagée par les trois éléments de liste, on est dans le cas d'une référence partagée, la modification affecte les trois éléments de la liste.
 [explanation]
 
 <hr/>
 Références partagées (3)
 =====
 
-On considère la variante suivante:
+On considère la variante suivante :
 
 <pre>
 cellule = [0]
@@ -71,7 +71,7 @@ Qu'obtient-on comme valeur pour <code>liste</code> ? :
 Références partagées (4)
 =====
 
-On considère enfin la variante suivante:
+On considère enfin la variante suivante :
 
 <pre>
 cellule = [0]
@@ -109,9 +109,9 @@ L'opérateur <code>*</code> sur les listes crée des références partagées, co
 
 Comment faire pour éviter que les trois éléments de liste ne soient modifiés ? : 
 
-( ) il faut faire une <em>shallow copy</em>
-( ) il faut faire une <em>deep copy</em>
-(x) il faut construire la liste autrement
+( ) Il faut faire une <em>shallow copy</em>.
+( ) Il faut faire une <em>deep copy</em>.
+(x) Il faut construire la liste autrement.
 
 [explanation]
 Dans ce cas, une <em>shallow copy</em> ou une <em>deep copy</em> ne sera d'aucune aide, puisque cela va créer un nouvel objet, mais avec la même structure, donc les mêmes références partagées que l'objet original. La seule solution est de construire la liste autrement.


### PR DESCRIPTION
Je vous dois quelques excuses car il se trouve que la dernière réforme de l'orthographe autorise désormais ambigüité. Cela dit, dans les compléments, il y avait aussi plusieurs occurrences de la graphie ambiguïté ; ainsi, l'ensemble sera harmonisé.  
Même remarque pour chaine et chaîne.
À ma décharge, le Larousse ne semble pas encore accepter ces nouvelles orthographes.