### PR TITLE
print module html n° lignes 521 et 522

### DIFF
--- a/w2/w2-s5-c2-presentation.ipynb
+++ b/w2/w2-s5-c2-presentation.ipynb
@@ -256,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dans ce fragment au contraire, vous voyez en ligne 522 qu'**il a fallu cette fois** insérer un *backslash* `\\` comme caractère de continuation pour que l'instruction puisse se poursuivre en ligne 523. "
+    "Dans ce fragment au contraire, vous voyez en ligne 521 qu'**il a fallu cette fois** insérer un *backslash* `\\` comme caractère de continuation pour que l'instruction puisse se poursuivre en ligne 522. "
    ]
   },
   {


### PR DESCRIPTION
Les numéros de lignes ont changés.
```
Fichier /opt/conda/lib/python3.6/pprint.py
----------------------------------------
<...>
519|        return "{%s}" % ", ".join(components), readable, recursive
520|
521|    if (issubclass(typ, list) and r is list.__repr__) or \
522|       (issubclass(typ, tuple) and r is tuple.__repr__):
523|        if issubclass(typ, list):
524|            if not object:
525|                return "[]", True, False
526|            format = "[%s]"
<...>
```