### PR TITLE
Update w2-s2-c4-expressions-regulieres.ipynb

### DIFF
--- a/w2/w2-s2-c4-expressions-regulieres.ipynb
+++ b/w2/w2-s2-c4-expressions-regulieres.ipynb
@@ -36,7 +36,7 @@
     "D'un côté il s'agit de manipulations de chaînes de caractères, mais d'un autre cela nécessite de créer des instances de classes, et donc d'avoir vu la programmation orientée objet.\n",
     "Du coup, les premières années nous les avions étudiées tout à la fin du cours, ce qui avait pu créer une certaine frustration.\n",
     "\n",
-    "C'est pourquoi nous avons décidé à présent de les étudier très tôt, dans cette séquence consacrée aux chaines de caractères. Les étudiants qui seraient décontenancés par ce contenu sont invités à y retourner après la semaine 6, consacrée à la programmation objet. \n",
+    "C'est pourquoi nous avons décidé à présent de les étudier très tôt, dans cette séquence consacrée aux chaînes de caractères. Les étudiants qui seraient décontenancés par ce contenu sont invités à y retourner après la semaine 6, consacrée à la programmation objet. \n",
     "\n",
     "Il nous semble important de savoir que ces fonctionnalités existent dans le langage, le détail de leur utilisation n'est toutefois pas critique, et on peut parfaitement faire l'impasse sur ce complément en première lecture.\n"
    ]
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Le langage Perl a été le premier à populariser l'utilisation des expressions régulières en les supportant nativement dans le langage, et non au travers d'une librairie. En python, les expressions régulières sont disponibles de manière plus traditionnelle, via le module `re` (regular expressions) de la librairie standard.\n",
+    "Le langage Perl a été le premier à populariser l'utilisation des expressions régulières en les supportant nativement dans le langage, et non au travers d'une librairie. En Python, les expressions régulières sont disponibles de manière plus traditionnelle, via le module `re` (regular expressions) de la librairie standard.\n",
     "Le propos de ce complément est de vous en donner une première introduction. "
    ]
   },
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pour ceux qui ne souhaitent pas approfondir, voici un premier exemple; on cherche à savoir si un objet `chaine` est ou non de la forme `*-*.txt`, et si oui, à calculer la partie de la chaine qui remplace le `*` :"
+    "Pour ceux qui ne souhaitent pas approfondir, voici un premier exemple ; on cherche à savoir si un objet `chaine` est ou non de la forme `*-*.txt`, et si oui, à calculer la partie de la chaîne qui remplace le `*` :"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# la chaine de départ\n",
+    "# la chaîne de départ\n",
     "chaine = \"abcdef.txt\""
    ]
   },
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# la fonction qui calcule si la chaine \"matche\" le pattern\n",
+    "# la fonction qui calcule si la chaîne \"matche\" le pattern\n",
     "match = re.match(regexp, chaine)\n",
     "match is None"
    ]
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Le fait que l'objet `match` vaut `None` indique que la chaine n'est pas de la bonne forme (il manque un `-` dans le nom); avec une autre chaine par contre :"
+    "Le fait que l'objet `match` vaut `None` indique que la chaîne n'est pas de la bonne forme (il manque un `-` dans le nom) ; avec une autre chaîne par contre :"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# la chaine de départ\n",
+    "# la chaîne de départ\n",
     "chaine = \"abc-def.txt\""
    ]
   },
@@ -188,7 +188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Approfondissons à présent: "
+    "Approfondissons à présent :"
    ]
   },
   {
@@ -278,7 +278,7 @@
     "\n",
     "    r\"\\w*[am]\\W\"\n",
     "    \n",
-    "Nous verrons tout à l'heure comment fabriquer des expressions régulières plus en détail, mais pour démystifier au moins celle-ci, on a mis bout à bout les morceaux suivants.\n",
+    "Nous verrons tout à l'heure comment fabriquer des expressions régulières plus en détail, mais pour démystifier au moins celle-ci, on a mis bout à bout les morceaux suivants :\n",
     " * `\\w*` : on veut trouver une sous-chaîne qui commence par un nombre quelconque, y compris nul (`*`) de caractères alphanumériques (`\\w`). Ceci est défini en fonction de votre LOCALE, on y reviendra.\n",
     " * `[am]` : immédiatement après, il nous faut trouver un caratère `a` ou `m`.\n",
     " * `\\W` : et enfin, il nous faut un caractère qui ne soit **pas** alphanumérique. Ceci est important puisqu'on cherche les mots qui **se terminent** par un `a` ou un `m`, si on ne le mettait pas on obtiendrait ceci"
@@ -308,7 +308,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Une autre forme simple d'utilisation des regexps est `re.split`, qui fournit une fonctionnalité voisine de `str.split`, mais ou les séparateurs sont exprimés comme une expression régulière"
+    "Une autre forme simple d'utilisation des regexps est `re.split`, qui fournit une fonctionnalité voisine de `str.split`, mais où les séparateurs sont exprimés comme une expression régulière"
    ]
   },
   {
@@ -362,7 +362,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ici, l'expression régulière (le premier argument) contient un **groupe**&nbsp;: on a utilisé des parenthèses autour du `\\w+`. Le second argument est la chaîne de remplacement, dans laquelle on a fait **référence au groupe** en écrivant `\\1`, qui veut dire tout simplement \"le premier groupe\".\n",
+    "Ici, l'expression régulière (le premier argument) contient un **groupe** : on a utilisé des parenthèses autour du `\\w+`. Le second argument est la chaîne de remplacement, dans laquelle on a fait **référence au groupe** en écrivant `\\1`, qui veut dire tout simplement \"le premier groupe\".\n",
     "\n",
     "Donc au final, l'effet de cet appel est d'entourer toutes les suites de caractères alphanumériques par `X` et `Y`. "
    ]
@@ -422,7 +422,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pour cela on considère ces trois chaines en entrée"
+    "Pour cela on considère ces trois chaînes en entrée"
    ]
   },
   {
@@ -521,8 +521,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ici plutôt que d'utiliser les raccourcis comme `\\w` j'ai préféré écrire explicitement les ensembles de caractères en jeu. De cette façon, on rend son code indépendant du LOCALE si c'est ce qu'on veut faire. Il y a deux morceaux qui interviennent tour à tour&nbsp;:\n",
-    " * `[0-9]+` signifie une suite de au moins un caractère dans l'intervalle `[0-9]`,\n",
+    "Ici plutôt que d'utiliser les raccourcis comme `\\w` j'ai préféré écrire explicitement les ensembles de caractères en jeu. De cette façon, on rend son code indépendant du LOCALE si c'est ce qu'on veut faire. Il y a deux morceaux qui interviennent tour à tour :\n",
+    " * `[0-9]+` signifie une suite d'au moins un caractère dans l'intervalle `[0-9]`,\n",
     " * `[A-Za-z]+` pour une suite d'au moins un caractère dans l'intervalle `[A-Z]` ou dans l'intervalle `[a-z]`. \n",
     " \n",
     "Et comme tout à l'heure on a simplement juxtaposé les morceaux dans le bon ordre pour construire l'expression régulière complète."
@@ -550,7 +550,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Maintenant, on va même pouvoir **donner un nom** à un morceau de la regexp, ici on désigne par `needle` le groupe de chiffres du milieu."
+    "Maintenant, on va même pouvoir **donner un nom** à un morceau de la regexp. Ici on désigne par `needle` le groupe de chiffres du milieu."
    ]
   },
   {
@@ -567,7 +567,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Et une fois que c'est fait, on peut demander à l'outil de nous **retrouver la partie correspondante** dans la chaine initiale:"
+    "Et une fois que c'est fait, on peut demander à l'outil de nous **retrouver la partie correspondante** dans la chaîne initiale :"
    ]
   },
   {
@@ -583,9 +583,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dans cette expression on a utilisé un **groupe nommé** `(?P<needle>[0-9]+)`, dans lequel&nbsp;:\n",
+    "Dans cette expression on a utilisé un **groupe nommé** `(?P<needle>[0-9]+)`, dans lequel :\n",
     " * les parenthèses définissent un groupe,\n",
-    " * `?P<needle>` spécifie que ce groupe pourra être référencé sous le nom `needle` (cette syntaxe très absconse est héritée semble-t-il de perl)."
+    " * `?P<needle>` spécifie que ce groupe pourra être référencé sous le nom `needle` (cette syntaxe très absconse est héritée semble-t-il de Perl)."
    ]
   },
   {
@@ -672,7 +672,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "La méthode recommandée pour utiliser la librairie, lorsque vous avez le même *pattern* à appliquer à un grand nombre de chaînes, est de&nbsp;:\n",
+    "La méthode recommandée pour utiliser la librairie, lorsque vous avez le même *pattern* à appliquer à un grand nombre de chaînes, est de :\n",
     " * compiler **une seule fois** votre chaîne en un automate, qui est matérialisé par un objet de la classe `re.RegexObject`, en utilisant `re.compile`, \n",
     " * puis d'**utiliser directement cet objet** autant de fois que vous avez de chaînes."
    ]
@@ -683,7 +683,7 @@
    "source": [
     "Nous avons utilisé dans les exemples plus haut (et nous continuerons plus bas pour une meilleure lisibilité) des **fonctions de commodité** du module, qui sont pratiques, par exemple, pour mettre au  point une expression régulière en mode interactif, mais qui ne **sont pas forcément** adaptées dans tous les cas. \n",
     "\n",
-    "Ces fonctions de commodité fonctionnent toutes sur le même principe&nbsp;:\n",
+    "Ces fonctions de commodité fonctionnent toutes sur le même principe :\n",
     "    \n",
     "`re.match(regexp, sample)`  $\\Longleftrightarrow$ `re.compile(regexp).match(sample)`\n",
     "\n",
@@ -744,7 +744,7 @@
    "metadata": {},
    "source": [
     "Les objets de la classe `RegexObject` représentent donc l'automate à état fini qui est le résultat de la compilation de l'expression régulière. \n",
-    "Pour résumer ce qu'on a déjà vu, les méthodes les plus utiles sur un objet `RegexObject` sont&nbsp;:\n",
+    "Pour résumer ce qu'on a déjà vu, les méthodes les plus utiles sur un objet `RegexObject` sont :\n",
     " * `match` et `search`, qui cherchent un *match* soit uniquement au début (`match`) ou n'importe où dans la chaîne (`search`),\n",
     " * `findall` et `split` pour chercher toutes les occurences (`findall`) ou leur négatif (`split`),\n",
     " * `sub` (qui aurait pu sans doute s'appeler `replace`, mais c'est comme ça) pour remplacer les occurrences de pattern."
@@ -921,7 +921,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Vous trouverez [une liste exhaustive de ces *flags* ici](https://docs.python.org/3/library/re.html#module-contents). Ils ont en général un nom long et parlant, et un alias court sur un seul caractère. Les plus utiles sont sans doute&nbsp;:\n",
+    "Vous trouverez [une liste exhaustive de ces *flags* ici](https://docs.python.org/3/library/re.html#module-contents). Ils ont en général un nom long et parlant, et un alias court sur un seul caractère. Les plus utiles sont sans doute :\n",
     " * `IGNORECASE` (*alias* `I`) pour, eh bien, ne pas faire la différence entre minuscules et majuscules,\n",
     " * `UNICODE` (*alias* `U`) pour rendre les séquences `\\w` et autres basées sur les propriétés des caractères dans la norme Unicode,\n",
     " * `LOCALE` (*alias* `L`) cette fois `\\w` dépend du `locale` courant,\n",
@@ -982,16 +982,16 @@
    "metadata": {},
    "source": [
     "Au commencement il faut spécifier des caractères.\n",
-    " * **un seul** caractère: \n",
-    "   * vous le citez tel quel, en le précédent d'un backslash `\\` s'il a par ailleurs un sens spécial dans le micro-langage de regexps (comme `+`, `*`, `[`, etc.);\n",
-    " * l'**attrape-tout** (*wildcard*):\n",
-    "    * un point `.` signifie \"n'importe quel caractère\";\n",
-    " * **un ensemble** de caractères avec la notation `[...]` qui permet de décrire par exemple:\n",
+    " * **un seul** caractère :\n",
+    "   * vous le citez tel quel, en le précédent d'un backslash `\\` s'il a par ailleurs un sens spécial dans le micro-langage de regexps (comme `+`, `*`, `[`, etc.) ;\n",
+    " * l'**attrape-tout** (*wildcard*) :\n",
+    "    * un point `.` signifie \"n'importe quel caractère\" ;\n",
+    " * **un ensemble** de caractères avec la notation `[...]` qui permet de décrire par exemple :\n",
     "   * `[a1=]` un ensemble in extenso, ici un caractère parmi `a`, `1`, ou `=`,\n",
     "   * `[a-z]` un intervalle de caractères, ici de `a` à `z`,\n",
     "   * `[15e-g]` un mélange des deux, ici un ensemble qui contiendrait `1`, `5`, `e`, `f` et `g`,\n",
-    "   * `[^15e-g]` une **négation**, qui a `^` comme premier caractère dans les `[]`, ici tout sauf l'ensemble précédent;\n",
-    " * un **ensemble prédéfini** de caractères, qui peuvent alors dépendre de l'environnement (UNICODE et LOCALE) avec entre autres les notations:\n",
+    "   * `[^15e-g]` une **négation**, qui a `^` comme premier caractère dans les `[]`, ici tout sauf l'ensemble précédent ;\n",
+    " * un **ensemble prédéfini** de caractères, qui peuvent alors dépendre de l'environnement (UNICODE et LOCALE) avec entre autres les notations :\n",
     "   * `\\w` les caractères alphanumériques, et `\\W` (les autres),\n",
     "   * `\\s` les caractères \"blancs\" - espace, tabulation, saut de ligne, etc., et `\\S` (les autres),\n",
     "   * `\\d` pour les chiffres, et `\\D` (les autres)."
@@ -1037,11 +1037,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Si je fais une analogie avec les montages électriques, jusqu'ici on a vu le montage en série, on met des expressions régulières bout à bout qui filtrent (`match`) la chaine en entrée séquentiellement du début à la fin. On a *un peu* de marge pour spécifier des alternatives, lorsqu'on fait par exemple\n",
+    "Si je fais une analogie avec les montages électriques, jusqu'ici on a vu le montage en série, on met des expressions régulières bout à bout qui filtrent (`match`) la chaîne en entrée séquentiellement du début à la fin. On a *un peu* de marge pour spécifier des alternatives, lorsqu'on fait par exemple\n",
     "\n",
     "    \"ab[cd]ef\"\n",
     "    \n",
-    "mais c'est limité à **un seul** caractère. Si on veut reconnaitre deux mots qui n'ont pas grand-chose à voir comme `abc` **ou** `def`, il faut en quelque sorte mettre deux regexps en parallèle, et c'est ce que permet l'opérateur `|`"
+    "mais c'est limité à **un seul** caractère. Si on veut reconnaître deux mots qui n'ont pas grand-chose à voir comme `abc` **ou** `def`, il faut en quelque sorte mettre deux regexps en parallèle, et c'est ce que permet l'opérateur `|`"
    ]
   },
   {
@@ -1070,13 +1070,13 @@
    "source": [
     "Selon que vous utilisez `match` ou `search`, vous précisez si vous vous intéressez uniquement à un match en début (`match`) ou n'importe où (`search`) dans la chaîne.\n",
     "\n",
-    "Mais indépendamment de cela, il peut être intéressant de \"coller\" l'expression en début ou en fin de ligne, et pour ça il existe des caractères spéciaux:\n",
-    " * `^` lorsqu'il est utilisé comme un caractère (c'est à dire pas en début de `[]`) signifie un début de chaîne;\n",
-    " * `\\A` a le même sens (sauf en mode MULTILINE), et je le recommande de préférence à `^` qui est déjà pas mal surchargé;\n",
-    " * `$` matche une fin de ligne;\n",
+    "Mais indépendamment de cela, il peut être intéressant de \"coller\" l'expression en début ou en fin de ligne, et pour ça il existe des caractères spéciaux :\n",
+    " * `^` lorsqu'il est utilisé comme un caractère (c'est-à-dire pas en début de `[]`) signifie un début de chaîne ;\n",
+    " * `\\A` a le même sens (sauf en mode MULTILINE), et je le recommande de préférence à `^` qui est déjà pas mal surchargé ;\n",
+    " * `$` matche une fin de ligne ;\n",
     " * `\\Z` est voisin mais pas tout à fait identique.\n",
     "\n",
-    "Reportez-vous à la documentation pour le détails des différences. Attention aussi à entrer le `^` correctement, il vous faut le caractère ASCII et non un voisin dans la ménagerie Unicode."
+    "Reportez-vous à la documentation pour le détail des différences. Attention aussi à entrer le `^` correctement, il vous faut le caractère ASCII et non un voisin dans la ménagerie Unicode."
    ]
   },
   {
@@ -1099,7 +1099,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On a en effet bien le pattern `bc` dans la chaine en entrée, mais il n'est ni au début ni à la fin."
+    "On a en effet bien le pattern `bc` dans la chaîne en entrée, mais il n'est ni au début ni à la fin."
    ]
   },
   {
@@ -1190,9 +1190,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Vous disposez des opérateurs suivants&nbsp;:\n",
+    "Vous disposez des opérateurs suivants :\n",
     " * `*` l'étoile qui signifie n'importe quel nombre, même nul, d'occurrences  - par exemple, `(ab)*` pour indiquer `''` ou `'ab'` ou `'abab'` ou etc.,\n",
-    " * `+` le plus qui signifie au moins une occurrence - e.g. `(ab)+` pour `ab` ou `abab` ou `ababab` ou etc,\n",
+    " * `+` le plus qui signifie au moins une occurrence - e.g. `(ab)+` pour `ab` ou `abab` ou `ababab` ou etc.,\n",
     " * `?` qui indique une option, c'est-à-dire 0 ou 1 occurence - autrement dit `(ab)?` matche `''` ou `ab`, \n",
     " * `{n}` pour exactement n occurrences de `(ab)` - e.g. `(ab){3}` qui serait exactement équivalent à `ababab`,\n",
     " * `{m,n}` entre m et n fois inclusivement."
@@ -1207,7 +1207,7 @@
     "samples = [n*'ab' for n in [0, 1, 3, 4]] + ['baba']\n",
     "\n",
     "for regexp in ['(ab)*', '(ab)+', '(ab){3}', '(ab){3,4}']:\n",
-    "    # on ajoute \\A \\Z pour matcher toute la chaine\n",
+    "    # on ajoute \\A \\Z pour matcher toute la chaîne\n",
     "    line_regexp = r\"\\A{}\\Z\".format(regexp)\n",
     "    for sample in samples:\n",
     "        match = re.match(line_regexp, sample)\n",
@@ -1225,12 +1225,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Nous avons déjà vu un exemple de groupe nommé (voir `needle` plus haut), les opérateurs que l'on peut citer dans cette catégorie sont&nbsp;:\n",
+    "Nous avons déjà vu un exemple de groupe nommé (voir `needle` plus haut), les opérateurs que l'on peut citer dans cette catégorie sont :\n",
     " * `(...)` les parenthèses définissent un groupe anonyme,\n",
     " * `(?P<name>...)` définit un groupe nommé,\n",
-    " * `(?:...)` permet de mettre des parenthèses mais sans créer un groupe, pour optimiser l'exécution puisqu'on n'a pas besoin de  conserver les liens vers la chaîne d'entrée,\n",
+    " * `(?:...)` permet de mettre des parenthèses mais sans créer de groupe, pour optimiser l'exécution puisqu'on n'a pas besoin de  conserver les liens vers la chaîne d'entrée,\n",
     " * `(?P=name)` qui ne matche que si l'on retrouve à cet endroit de l'entrée la même sous-chaîne que celle trouvée pour le groupe `name` en amont,\n",
-    " * enfin `(?=...)`, `(?!...)`et `(?<=...)` permettent des contraintes encore plus élaborées, nous vous laissons le soin d'expérimenter avec elles si vous êtes intéressés; sachez toutefois que l'utilisation de telles constructions peut en théorie rendre l'interprétation de votre expression régulière beaucoup moins efficace."
+    " * enfin `(?=...)`, `(?!...)`et `(?<=...)` permettent des contraintes encore plus élaborées, nous vous laissons le soin d'expérimenter avec elles si vous êtes intéressé ; sachez toutefois que l'utilisation de telles constructions peut en théorie rendre l'interprétation de votre expression régulière beaucoup moins efficace."
    ]
   },
   {
@@ -1271,7 +1271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ça n'est pas forcément ce qu'on voulait faire, aussi on peut spécifier l'approche inverse, c'est-à-dire de trouver la **plus-petite** chaîne qui matche, dans une approche dite *non-greedy*, avec les opérateurs suivants&nbsp;:\n",
+    "Ça n'est pas forcément ce qu'on voulait faire, aussi on peut spécifier l'approche inverse, c'est-à-dire trouver la **plus-petite** chaîne qui matche, dans une approche dite *non-greedy*, avec les opérateurs suivants :\n",
     " * `*?` : `*` mais *non-greedy*,\n",
     " * `+?` : `+` mais *non-greedy*,\n",
     " * `??` : `?` mais *non-greedy*,"
@@ -1434,10 +1434,10 @@
     " * l'**analyse lexicale**, qui découpe le texte en morceaux (qu'on appelle des *tokens*),\n",
     " * et l'**analyse syntaxique** qui décrit pour simplifier à l'extrême l'ordre dans lequel on peut trouver les tokens.\n",
     " \n",
-    "Avec les expression régulières, on adresse le niveau de l'analyse lexicale. Pour l'analyse syntaxique, qui est franchement au delà des objectifs de ce cours, il existe de nombreuses alternatives, parmi lesquelles:\n",
+    "Avec les expression régulières, on adresse le niveau de l'analyse lexicale. Pour l'analyse syntaxique, qui est franchement au-delà des objectifs de ce cours, il existe de nombreuses alternatives, parmi lesquelles :\n",
     " * [`pyparsing`](http://pyparsing.wikispaces.com/Download+and+Installation)\n",
     " * [`PLY` (Python Lex-Yacc)](http://www.dabeaz.com/ply/)\n",
-    " * [`ANTLR`](http://www.antlr.org) qui est un outil écrit en Java mais qui peut générer des parsers en python,\n",
+    " * [`ANTLR`](http://www.antlr.org) qui est un outil écrit en Java mais qui peut générer des parsers en Python,\n",
     " * ...\n"
    ]
   }

--- a/w2/w2-s2-c4-expressions-regulieres.ipynb
+++ b/w2/w2-s2-c4-expressions-regulieres.ipynb
@@ -33,10 +33,10 @@
     "\n",
     "Après avoir joué ce cours plusieurs années de suite, l'expérience nous montre qu'il est difficile de trouver le bon moment pour appréhender les expressions régulières.\n",
     "\n",
-    "D'un côté il s'agit de manipulations de chaînes de caractères, mais d'un autre cela nécessite de créer des instances de classes, et donc d'avoir vu la programmation orientée objet.\n",
+    "D'un côté il s'agit de manipulations de chaines de caractères, mais d'un autre cela nécessite de créer des instances de classes, et donc d'avoir vu la programmation orientée objet.\n",
     "Du coup, les premières années nous les avions étudiées tout à la fin du cours, ce qui avait pu créer une certaine frustration.\n",
     "\n",
-    "C'est pourquoi nous avons décidé à présent de les étudier très tôt, dans cette séquence consacrée aux chaînes de caractères. Les étudiants qui seraient décontenancés par ce contenu sont invités à y retourner après la semaine 6, consacrée à la programmation objet. \n",
+    "C'est pourquoi nous avons décidé à présent de les étudier très tôt, dans cette séquence consacrée aux chaines de caractères. Les étudiants qui seraient décontenancés par ce contenu sont invités à y retourner après la semaine 6, consacrée à la programmation objet. \n",
     "\n",
     "Il nous semble important de savoir que ces fonctionnalités existent dans le langage, le détail de leur utilisation n'est toutefois pas critique, et on peut parfaitement faire l'impasse sur ce complément en première lecture.\n"
    ]
@@ -49,7 +49,7 @@
     "\n",
     "    $ dir *.txt\n",
     "\n",
-    "(ou `ls *.txt` sur linux ou mac), vous utilisez l'expression régulière `*.txt` qui désigne tous les fichiers dont le nom se termine par `.txt`. On dit que l'expression régulière *filtre* toutes les chaînes qui se terminent par `.txt` (l'expression anglaise consacrée est le *pattern matching*)."
+    "(ou `ls *.txt` sur linux ou mac), vous utilisez l'expression régulière `*.txt` qui désigne tous les fichiers dont le nom se termine par `.txt`. On dit que l'expression régulière *filtre* toutes les chaines qui se terminent par `.txt` (l'expression anglaise consacrée est le *pattern matching*)."
    ]
   },
   {
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pour ceux qui ne souhaitent pas approfondir, voici un premier exemple ; on cherche à savoir si un objet `chaine` est ou non de la forme `*-*.txt`, et si oui, à calculer la partie de la chaîne qui remplace le `*` :"
+    "Pour ceux qui ne souhaitent pas approfondir, voici un premier exemple ; on cherche à savoir si un objet `chaine` est ou non de la forme `*-*.txt`, et si oui, à calculer la partie de la chaine qui remplace le `*` :"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# la chaîne de départ\n",
+    "# la chaine de départ\n",
     "chaine = \"abcdef.txt\""
    ]
   },
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# la fonction qui calcule si la chaîne \"matche\" le pattern\n",
+    "# la fonction qui calcule si la chaine \"matche\" le pattern\n",
     "match = re.match(regexp, chaine)\n",
     "match is None"
    ]
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Le fait que l'objet `match` vaut `None` indique que la chaîne n'est pas de la bonne forme (il manque un `-` dans le nom) ; avec une autre chaîne par contre :"
+    "Le fait que l'objet `match` vaut `None` indique que la chaine n'est pas de la bonne forme (il manque un `-` dans le nom) ; avec une autre chaine par contre :"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# la chaîne de départ\n",
+    "# la chaine de départ\n",
     "chaine = \"abc-def.txt\""
    ]
   },
@@ -195,7 +195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dans un terminal, `*.txt` est une expression régulière très simple. Le module `re` fournit le moyen de construire des expressions régulières très élaborées et plus puissantes que ce que supporte le terminal. C'est pourquoi la syntaxe des regexps de `re` est un peu différente. Par exemple comme on vient de le voir, pour filtrer la même famille de chaînes que `*-*.txt` avec le module `re`, il nous a fallu écrire l'expression régulière sous une forme légèrement différente."
+    "Dans un terminal, `*.txt` est une expression régulière très simple. Le module `re` fournit le moyen de construire des expressions régulières très élaborées et plus puissantes que ce que supporte le terminal. C'est pourquoi la syntaxe des regexps de `re` est un peu différente. Par exemple comme on vient de le voir, pour filtrer la même famille de chaines que `*-*.txt` avec le module `re`, il nous a fallu écrire l'expression régulière sous une forme légèrement différente."
    ]
   },
   {
@@ -239,7 +239,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On se donne deux exemples de chaînes"
+    "On se donne deux exemples de chaines"
    ]
   },
   {
@@ -256,7 +256,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On peut **chercher tous** les mots se terminant par `a` ou `m` dans une chaîne avec `findall`"
+    "On peut **chercher tous** les mots se terminant par `a` ou `m` dans une chaine avec `findall`"
    ]
   },
   {
@@ -279,7 +279,7 @@
     "    r\"\\w*[am]\\W\"\n",
     "    \n",
     "Nous verrons tout à l'heure comment fabriquer des expressions régulières plus en détail, mais pour démystifier au moins celle-ci, on a mis bout à bout les morceaux suivants :\n",
-    " * `\\w*` : on veut trouver une sous-chaîne qui commence par un nombre quelconque, y compris nul (`*`) de caractères alphanumériques (`\\w`). Ceci est défini en fonction de votre LOCALE, on y reviendra.\n",
+    " * `\\w*` : on veut trouver une sous-chaine qui commence par un nombre quelconque, y compris nul (`*`) de caractères alphanumériques (`\\w`). Ceci est défini en fonction de votre LOCALE, on y reviendra.\n",
     " * `[am]` : immédiatement après, il nous faut trouver un caratère `a` ou `m`.\n",
     " * `\\W` : et enfin, il nous faut un caractère qui ne soit **pas** alphanumérique. Ceci est important puisqu'on cherche les mots qui **se terminent** par un `a` ou un `m`, si on ne le mettait pas on obtiendrait ceci"
    ]
@@ -362,7 +362,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ici, l'expression régulière (le premier argument) contient un **groupe** : on a utilisé des parenthèses autour du `\\w+`. Le second argument est la chaîne de remplacement, dans laquelle on a fait **référence au groupe** en écrivant `\\1`, qui veut dire tout simplement \"le premier groupe\".\n",
+    "Ici, l'expression régulière (le premier argument) contient un **groupe** : on a utilisé des parenthèses autour du `\\w+`. Le second argument est la chaine de remplacement, dans laquelle on a fait **référence au groupe** en écrivant `\\1`, qui veut dire tout simplement \"le premier groupe\".\n",
     "\n",
     "Donc au final, l'effet de cet appel est d'entourer toutes les suites de caractères alphanumériques par `X` et `Y`. "
    ]
@@ -378,7 +378,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "En guise de digression, il n'y a aucune obligation à utiliser un *raw-string*, d'ailleurs on rappelle qu'il n'y a pas de différence de nature entre un *raw-string* et une chaîne usuelle"
+    "En guise de digression, il n'y a aucune obligation à utiliser un *raw-string*, d'ailleurs on rappelle qu'il n'y a pas de différence de nature entre un *raw-string* et une chaine usuelle"
    ]
   },
   {
@@ -389,7 +389,7 @@
    "source": [
     "raw = r'abc'\n",
     "regular = 'abc'\n",
-    "# comme on a pris une 'petite' chaîne ce sont les mêmes objets\n",
+    "# comme on a pris une 'petite' chaine ce sont les mêmes objets\n",
     "print(f\"both compared with is → {raw is regular}\")\n",
     "# et donc a fortiori\n",
     "print(f\"both compared with == → {raw == regular}\")"
@@ -399,7 +399,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Il se trouve que le *backslash* `\\` à l'intérieur des expressions régulières est d'un usage assez courant - on l'a vu déjà plusieurs fois. C'est pourquoi on **utilise fréquemment un *raw-string*** pour décrire une expression régulière, et en général à chaque fois qu'elle comporte un *backslash*. On rappelle que le raw-string désactive l'interprétation des `\\` à l'intérieur de la chaîne, par exemple, `\\t` est interprété comme un caractère de tabulation. Sans raw-string, il faut doubler tous les `\\` pour qu'il n'y ait pas d'interprétation."
+    "Il se trouve que le *backslash* `\\` à l'intérieur des expressions régulières est d'un usage assez courant - on l'a vu déjà plusieurs fois. C'est pourquoi on **utilise fréquemment un *raw-string*** pour décrire une expression régulière, et en général à chaque fois qu'elle comporte un *backslash*. On rappelle que le raw-string désactive l'interprétation des `\\` à l'intérieur de la chaine, par exemple, `\\t` est interprété comme un caractère de tabulation. Sans raw-string, il faut doubler tous les `\\` pour qu'il n'y ait pas d'interprétation."
    ]
   },
   {
@@ -413,16 +413,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Nous allons maintenant voir comment on peut d'abord vérifier si une chaîne est conforme au critère défini par l'expression régulière, mais aussi *extraire* les morceaux de la chaîne qui correspondent aux différentes parties de l'expression. \n",
+    "Nous allons maintenant voir comment on peut d'abord vérifier si une chaine est conforme au critère défini par l'expression régulière, mais aussi *extraire* les morceaux de la chaine qui correspondent aux différentes parties de l'expression. \n",
     "\n",
-    "Pour cela, supposons qu'on s'intéresse aux chaînes qui comportent 5 parties, une suite de chiffres, une suite de lettres, des chiffres à nouveau, des lettres et enfin de nouveau des chiffres."
+    "Pour cela, supposons qu'on s'intéresse aux chaines qui comportent 5 parties, une suite de chiffres, une suite de lettres, des chiffres à nouveau, des lettres et enfin de nouveau des chiffres."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pour cela on considère ces trois chaînes en entrée"
+    "Pour cela on considère ces trois chaines en entrée"
    ]
   },
   {
@@ -448,7 +448,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pour commencer, voyons que l'on peut facilement **vérifier si une chaîne vérifie** ou non le critère."
+    "Pour commencer, voyons que l'on peut facilement **vérifier si une chaine vérifie** ou non le critère."
    ]
   },
   {
@@ -567,7 +567,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Et une fois que c'est fait, on peut demander à l'outil de nous **retrouver la partie correspondante** dans la chaîne initiale :"
+    "Et une fois que c'est fait, on peut demander à l'outil de nous **retrouver la partie correspondante** dans la chaine initiale :"
    ]
   },
   {
@@ -599,7 +599,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Enfin, et c'est un trait qui n'est pas présent dans tous les langages, on peut restreindre un morceau de chaîne à être identique à un groupe déjà vu plus tôt dans la chaîne. Dans l'exemple ci-dessus, on pourrait ajouter comme contrainte que le premier et le dernier groupes de chiffres soient identiques, comme ceci"
+    "Enfin, et c'est un trait qui n'est pas présent dans tous les langages, on peut restreindre un morceau de chaine à être identique à un groupe déjà vu plus tôt dans la chaine. Dans l'exemple ci-dessus, on pourrait ajouter comme contrainte que le premier et le dernier groupes de chiffres soient identiques, comme ceci"
    ]
   },
   {
@@ -663,7 +663,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Comme vous le savez peut-être, une expression régulière décrite sous forme de chaîne, comme par exemple `\"\\w*[am]\\W\"`, peut être traduite dans un **automate fini** qui permet de faire le filtrage avec une chaîne. C'est ce qui explique le *workflow* que nous avons résumé dans cette figure.\n",
+    "Comme vous le savez peut-être, une expression régulière décrite sous forme de chaine, comme par exemple `\"\\w*[am]\\W\"`, peut être traduite dans un **automate fini** qui permet de faire le filtrage avec une chaine. C'est ce qui explique le *workflow* que nous avons résumé dans cette figure.\n",
     "\n",
     "<img src=\"media/re-workflow.png\">"
    ]
@@ -672,9 +672,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "La méthode recommandée pour utiliser la librairie, lorsque vous avez le même *pattern* à appliquer à un grand nombre de chaînes, est de :\n",
-    " * compiler **une seule fois** votre chaîne en un automate, qui est matérialisé par un objet de la classe `re.RegexObject`, en utilisant `re.compile`, \n",
-    " * puis d'**utiliser directement cet objet** autant de fois que vous avez de chaînes."
+    "La méthode recommandée pour utiliser la librairie, lorsque vous avez le même *pattern* à appliquer à un grand nombre de chaines, est de :\n",
+    " * compiler **une seule fois** votre chaine en un automate, qui est matérialisé par un objet de la classe `re.RegexObject`, en utilisant `re.compile`, \n",
+    " * puis d'**utiliser directement cet objet** autant de fois que vous avez de chaines."
    ]
   },
   {
@@ -687,7 +687,7 @@
     "    \n",
     "`re.match(regexp, sample)`  $\\Longleftrightarrow$ `re.compile(regexp).match(sample)`\n",
     "\n",
-    "Donc à chaque fois qu'on utilise une fonction de commodité, on recompile la chaîne en automate, ce qui, dès qu'on a plus d'une chaîne à traiter, représente un surcoût."
+    "Donc à chaque fois qu'on utilise une fonction de commodité, on recompile la chaine en automate, ce qui, dès qu'on a plus d'une chaine à traiter, représente un surcoût."
    ]
   },
   {
@@ -700,7 +700,7 @@
    "source": [
     "# au lieu de faire comme ci-dessus:\n",
     "\n",
-    "# imaginez 10**6 chaînes dans samples\n",
+    "# imaginez 10**6 chaines dans samples\n",
     "for sample in samples:\n",
     "    match = re.match(regexp3, sample)\n",
     "    print(f\"{sample:>16s} → {nice(match)}\")    "
@@ -716,7 +716,7 @@
    "source": [
     "# dans du vrai code on fera plutôt:\n",
     "\n",
-    "# on compile la chaîne en automate une seule fois\n",
+    "# on compile la chaine en automate une seule fois\n",
     "re_obj3 = re.compile(regexp3)\n",
     "\n",
     "# ensuite on part directement de l'automate\n",
@@ -729,7 +729,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Cette deuxième version ne compile qu'une fois la chaîne en automate, et donc est plus efficace."
+    "Cette deuxième version ne compile qu'une fois la chaine en automate, et donc est plus efficace."
    ]
   },
   {
@@ -745,7 +745,7 @@
    "source": [
     "Les objets de la classe `RegexObject` représentent donc l'automate à état fini qui est le résultat de la compilation de l'expression régulière. \n",
     "Pour résumer ce qu'on a déjà vu, les méthodes les plus utiles sur un objet `RegexObject` sont :\n",
-    " * `match` et `search`, qui cherchent un *match* soit uniquement au début (`match`) ou n'importe où dans la chaîne (`search`),\n",
+    " * `match` et `search`, qui cherchent un *match* soit uniquement au début (`match`) ou n'importe où dans la chaine (`search`),\n",
     " * `findall` et `split` pour chercher toutes les occurences (`findall`) ou leur négatif (`split`),\n",
     " * `sub` (qui aurait pu sans doute s'appeler `replace`, mais c'est comme ça) pour remplacer les occurrences de pattern."
    ]
@@ -804,7 +804,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`group`, `groups`, `groupdict` pour retrouver les morceaux de la chaîne d'entrée qui correspondent aux **groupes** de la regexp. On peut y accéder par rang, ou par nom (comme on l'a vu plus haut avec `needle`)."
+    "`group`, `groups`, `groupdict` pour retrouver les morceaux de la chaine d'entrée qui correspondent aux **groupes** de la regexp. On peut y accéder par rang, ou par nom (comme on l'a vu plus haut avec `needle`)."
    ]
   },
   {
@@ -858,7 +858,7 @@
    "source": [
     " Comme on le voit pour l'accès par rang **les indices commencent à 1** pour des raisons historiques (on peut déjà référencer `\\1` en sed depuis la fin des années 70). \n",
     " \n",
-    " On peut aussi accéder au **groupe 0** comme étant la partie de la chaîne de départ qui a effectivement été filtrée par l'expression régulière, et qui peut tout à fait être au beau milieu de la chaîne de départ, comme dans notre exemple"
+    " On peut aussi accéder au **groupe 0** comme étant la partie de la chaine de départ qui a effectivement été filtrée par l'expression régulière, et qui peut tout à fait être au beau milieu de la chaine de départ, comme dans notre exemple"
    ]
   },
   {
@@ -890,7 +890,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`span` pour connaître les index dans la chaîne d'entrée pour un groupe donné."
+    "`span` pour connaitre les index dans la chaine d'entrée pour un groupe donné."
    ]
   },
   {
@@ -914,7 +914,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Enfin il faut noter qu'on peut passer à `re.compile` un certain nombre de *flags* qui modifient globalement l'interprétation de la chaîne, et qui peuvent rendre service. "
+    "Enfin il faut noter qu'on peut passer à `re.compile` un certain nombre de *flags* qui modifient globalement l'interprétation de la chaine, et qui peuvent rendre service. "
    ]
   },
   {
@@ -1014,7 +1014,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Pour ce dernier exemple, comme on a backslashé le `.` il faut que la chaîne en entrée contienne vraiment un `.`"
+    "Pour ce dernier exemple, comme on a backslashé le `.` il faut que la chaine en entrée contienne vraiment un `.`"
    ]
   },
   {
@@ -1037,11 +1037,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Si je fais une analogie avec les montages électriques, jusqu'ici on a vu le montage en série, on met des expressions régulières bout à bout qui filtrent (`match`) la chaîne en entrée séquentiellement du début à la fin. On a *un peu* de marge pour spécifier des alternatives, lorsqu'on fait par exemple\n",
+    "Si je fais une analogie avec les montages électriques, jusqu'ici on a vu le montage en série, on met des expressions régulières bout à bout qui filtrent (`match`) la chaine en entrée séquentiellement du début à la fin. On a *un peu* de marge pour spécifier des alternatives, lorsqu'on fait par exemple\n",
     "\n",
     "    \"ab[cd]ef\"\n",
     "    \n",
-    "mais c'est limité à **un seul** caractère. Si on veut reconnaître deux mots qui n'ont pas grand-chose à voir comme `abc` **ou** `def`, il faut en quelque sorte mettre deux regexps en parallèle, et c'est ce que permet l'opérateur `|`"
+    "mais c'est limité à **un seul** caractère. Si on veut reconnaitre deux mots qui n'ont pas grand-chose à voir comme `abc` **ou** `def`, il faut en quelque sorte mettre deux regexps en parallèle, et c'est ce que permet l'opérateur `|`"
    ]
   },
   {
@@ -1061,17 +1061,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Fin(s) de chaîne"
+    "##### Fin(s) de chaine"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Selon que vous utilisez `match` ou `search`, vous précisez si vous vous intéressez uniquement à un match en début (`match`) ou n'importe où (`search`) dans la chaîne.\n",
+    "Selon que vous utilisez `match` ou `search`, vous précisez si vous vous intéressez uniquement à un match en début (`match`) ou n'importe où (`search`) dans la chaine.\n",
     "\n",
     "Mais indépendamment de cela, il peut être intéressant de \"coller\" l'expression en début ou en fin de ligne, et pour ça il existe des caractères spéciaux :\n",
-    " * `^` lorsqu'il est utilisé comme un caractère (c'est-à-dire pas en début de `[]`) signifie un début de chaîne ;\n",
+    " * `^` lorsqu'il est utilisé comme un caractère (c'est-à-dire pas en début de `[]`) signifie un début de chaine ;\n",
     " * `\\A` a le même sens (sauf en mode MULTILINE), et je le recommande de préférence à `^` qui est déjà pas mal surchargé ;\n",
     " * `$` matche une fin de ligne ;\n",
     " * `\\Z` est voisin mais pas tout à fait identique.\n",
@@ -1099,7 +1099,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On a en effet bien le pattern `bc` dans la chaîne en entrée, mais il n'est ni au début ni à la fin."
+    "On a en effet bien le pattern `bc` dans la chaine en entrée, mais il n'est ni au début ni à la fin."
    ]
   },
   {
@@ -1176,7 +1176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "dans cet exemple, on n'a utilisé qu'un seul groupe `()`, et le morceau de chaîne qui correspond à ce groupe se trouve donc être le seul groupe retourné par `MatchObject.group`."
+    "dans cet exemple, on n'a utilisé qu'un seul groupe `()`, et le morceau de chaine qui correspond à ce groupe se trouve donc être le seul groupe retourné par `MatchObject.group`."
    ]
   },
   {
@@ -1207,7 +1207,7 @@
     "samples = [n*'ab' for n in [0, 1, 3, 4]] + ['baba']\n",
     "\n",
     "for regexp in ['(ab)*', '(ab)+', '(ab){3}', '(ab){3,4}']:\n",
-    "    # on ajoute \\A \\Z pour matcher toute la chaîne\n",
+    "    # on ajoute \\A \\Z pour matcher toute la chaine\n",
     "    line_regexp = r\"\\A{}\\Z\".format(regexp)\n",
     "    for sample in samples:\n",
     "        match = re.match(line_regexp, sample)\n",
@@ -1228,8 +1228,8 @@
     "Nous avons déjà vu un exemple de groupe nommé (voir `needle` plus haut), les opérateurs que l'on peut citer dans cette catégorie sont :\n",
     " * `(...)` les parenthèses définissent un groupe anonyme,\n",
     " * `(?P<name>...)` définit un groupe nommé,\n",
-    " * `(?:...)` permet de mettre des parenthèses mais sans créer de groupe, pour optimiser l'exécution puisqu'on n'a pas besoin de  conserver les liens vers la chaîne d'entrée,\n",
-    " * `(?P=name)` qui ne matche que si l'on retrouve à cet endroit de l'entrée la même sous-chaîne que celle trouvée pour le groupe `name` en amont,\n",
+    " * `(?:...)` permet de mettre des parenthèses mais sans créer de groupe, pour optimiser l'exécution puisqu'on n'a pas besoin de  conserver les liens vers la chaine d'entrée,\n",
+    " * `(?P=name)` qui ne matche que si l'on retrouve à cet endroit de l'entrée la même sous-chaine que celle trouvée pour le groupe `name` en amont,\n",
     " * enfin `(?=...)`, `(?!...)`et `(?<=...)` permettent des contraintes encore plus élaborées, nous vous laissons le soin d'expérimenter avec elles si vous êtes intéressé ; sachez toutefois que l'utilisation de telles constructions peut en théorie rendre l'interprétation de votre expression régulière beaucoup moins efficace."
    ]
   },
@@ -1271,7 +1271,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ça n'est pas forcément ce qu'on voulait faire, aussi on peut spécifier l'approche inverse, c'est-à-dire trouver la **plus-petite** chaîne qui matche, dans une approche dite *non-greedy*, avec les opérateurs suivants :\n",
+    "Ça n'est pas forcément ce qu'on voulait faire, aussi on peut spécifier l'approche inverse, c'est-à-dire trouver la **plus-petite** chaine qui matche, dans une approche dite *non-greedy*, avec les opérateurs suivants :\n",
     " * `*?` : `*` mais *non-greedy*,\n",
     " * `+?` : `+` mais *non-greedy*,\n",
     " * `??` : `?` mais *non-greedy*,"


### PR DESCRIPTION
Avec ou sans accent circonflexe sur les i, les deux sont autorisés avec la nouvelle orthographe (https://www.orthographe-recommandee.info/enseignement/regles.pdf) mais il vaut mieux être homogène.